### PR TITLE
Replace old dask scaling function with new method.

### DIFF
--- a/scripts/process_cesm_output.py
+++ b/scripts/process_cesm_output.py
@@ -43,8 +43,7 @@ def main():
                                      out_format=config["out_format"])
     else:
         cluster = LocalCluster(n_workers=0)
-        for i in range(args.proc):
-            cluster.start_worker(ncores=1)
+        cluster.scale(args.proc)
         client = Client(cluster)
         print(client)
         futures = client.map(process_cesm_file_subset, filenames,


### PR DESCRIPTION
Old dask cluster method was removed in recent versions of dask causing an error. Replaced with new scaling method.